### PR TITLE
Update mods.json

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -22,5 +22,9 @@
   {
     "name": "MFrameworkLoader",
     "repo": "https://github.com/MidgetBrony/MFrameWorkLoader"
+  },
+  {
+    "name": "NoSteam",
+    "repo": "https://github.com/Rafacasari/DesktopMate-NoSteam"
   }
 ]


### PR DESCRIPTION
## Mod Submission

### Checklist
- [x] I have added my mod to the bottom of `mods.json`
- [x] My repository contains a valid `dskt.json` file
- [x] My mod follows the [submission guidelines](https://dskt.cc/docs/submitting-mods)
- [x] I have tested my mod with the latest version of Desktop Mate

### Repository URL
https://github.com/Rafacasari/DesktopMate-NoSteam

### Additional Notes
A MelonLoader Mod to enable "offline mode" in Desktop Mate (when Steam is closed). This can be useful if you want to have Desktop Mate on Windows Startup but don't want Steam to open with it.

### Screenshots
There is no visual changes.
